### PR TITLE
ROS Distro fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(argos_bridge)
 find_package(catkin REQUIRED COMPONENTS
   std_msgs
   message_generation
+  roscpp
 )
 
 ## System dependencies are found with CMake's conventions
@@ -103,8 +104,8 @@ generate_messages(
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES argos_bridge
-  CATKIN_DEPENDS std_msgs
-  DEPENDS message_runtime
+  CATKIN_DEPENDS roscpp std_msgs
+  DEPENDS message_runtime 
 )
 
 ###########

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Issues
   Go ahead and do 'catkin_make' then uncomment the line and do another
   'catkin_make'.  This should only occur once.
 
+- If there are issues related to ros::console::initialized, check your ROS version
+and if the ROS_DISTRO env is set. The argos_bridge/ros_lib_links/libroscpp.so should
+normally point to libroscpp.so of your distro. To change this type:
+
+    ld -sf /opt/ros/YOUR_ROS/lib/libroscpp.so libroscpp.so
+ 
+  Assuming you are in ros_lib_links folder.  
 
 Author
 ------

--- a/README.md
+++ b/README.md
@@ -60,12 +60,7 @@ Issues
   'catkin_make'.  This should only occur once.
 
 - If there are issues related to ros::console::initialized, check your ROS version
-and if the ROS_DISTRO env is set. The argos_bridge/ros_lib_links/libroscpp.so should
-normally point to libroscpp.so of your distro. To change this type:
-
-    ld -sf /opt/ros/YOUR_ROS/lib/libroscpp.so libroscpp.so
- 
-  Assuming you are in ros_lib_links folder.  
+and if the ROS_DISTRO env is set.   
 
 Author
 ------

--- a/package.xml
+++ b/package.xml
@@ -43,6 +43,10 @@
   <build_depend>std_msgs</build_depend>
   <run_depend>std_msgs</run_depend>
 
+  <build_depend>roscpp</build_depend>
+  <run_depend>roscpp</run_depend>
+
+
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/plugin/argos_ros_bot/CMakeLists.txt
+++ b/plugin/argos_ros_bot/CMakeLists.txt
@@ -2,4 +2,5 @@ add_library(argos_ros_bot MODULE argos_ros_bot.h argos_ros_bot.cpp)
 target_link_libraries(argos_ros_bot
   argos3core_simulator
   argos3plugin_simulator_footbot
-  argos3plugin_simulator_genericrobot)
+  argos3plugin_simulator_genericrobot
+  /opt/ros/$ENV{ROS_DISTRO}/lib/libroscpp.so)

--- a/ros_lib_links/libroscpp.so
+++ b/ros_lib_links/libroscpp.so
@@ -1,1 +1,0 @@
-/opt/ros/indigo/lib/libroscpp.so


### PR DESCRIPTION
If using non other than Indigo ROS version, during compilation or runtime some erros related to roscpp can apper. This pull request adds the neccesary dependencies. 